### PR TITLE
More updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@
 
 # Go workspace file
 go.work
-owl2protobuf
+owl2proto
+proto.go
 

--- a/cmd/owl2protobuf/owl2protobuf.go
+++ b/cmd/owl2protobuf/owl2protobuf.go
@@ -195,9 +195,6 @@ message ResourceID {
 
 	// Create proto messages with comments
 	for _, v := range preparedOntology.Resources {
-		if v.Iri == "http://graph.clouditor.io/classes/ApplicationLog" {
-			fmt.Println("Stop here")
-		}
 		// is the counter for the message field numbers
 		i := 0
 

--- a/cmd/owl2protobuf/owl2protobuf.go
+++ b/cmd/owl2protobuf/owl2protobuf.go
@@ -202,8 +202,9 @@ message ResourceID {
 		i := 0
 
 		// Add comment
-		for _, v := range v.Comment {
-			output += "\n// " + v
+		for _, w := range v.Comment {
+			output += fmt.Sprintf("\n// %s is an entity in our Cloud ontology", v.Name)
+			output += "\n// " + w
 		}
 
 		// Start message
@@ -217,7 +218,7 @@ message ResourceID {
 				if r.Comment != "" {
 					output += fmt.Sprintf("\n\t// %s", r.Comment)
 				}
-				output += fmt.Sprintf("\n\t%s %s  = %d;", r.Typ, r.Value, i)
+				output += fmt.Sprintf("\n\t%s %s  = %d;", r.Typ, util.ToSnakeCase(r.Value), i)
 			}
 		}
 
@@ -226,7 +227,7 @@ message ResourceID {
 			if o.Name != "" && o.ObjectProperty != "" {
 				i += 1
 				value, typ := util.GetObjectDetail(o.ObjectProperty, rootResourceName, preparedOntology.Resources[o.Class], preparedOntology)
-				output += fmt.Sprintf("\n\t%s%s %s  = %d;", value, typ, o.Name, i)
+				output += fmt.Sprintf("\n\t%s%s %s  = %d;", value, typ, util.ToSnakeCase(o.Name), i)
 			}
 		}
 

--- a/cmd/owl2protobuf/owl2protobuf.go
+++ b/cmd/owl2protobuf/owl2protobuf.go
@@ -65,14 +65,13 @@ func prepareOntology(o owl.Ontology) ontology.OntologyPrepared {
 
 	// Prepare name and comment
 	for _, aa := range o.AnnotationAssertion {
-		// if aa.AnnotationProperty.AbbreviatedIRI == "rdfs:label" {
-		// 	if _, ok := preparedOntology.Resources[aa.IRI]; ok {
-		// 		preparedOntology.Resources[aa.IRI].Name = util.CleanString(aa.Literal)
-		// 	} else if _, ok := preparedOntology.AnnotationAssertion[aa.AbbreviatedIRI]; ok {
-		// 		preparedOntology.Resources[aa.AbbreviatedIRI].Name = util.CleanString(aa.Literal)
-		// 	}
-		// } else
-		if aa.AnnotationProperty.AbbreviatedIRI == "rdfs:comment" {
+		if aa.AnnotationProperty.AbbreviatedIRI == "rdfs:label" {
+			if _, ok := preparedOntology.Resources[aa.IRI]; ok {
+				preparedOntology.Resources[aa.IRI].Name = util.CleanString(aa.Literal)
+			} else if _, ok := preparedOntology.AnnotationAssertion[aa.AbbreviatedIRI]; ok {
+				preparedOntology.Resources[aa.AbbreviatedIRI].Name = util.CleanString(aa.Literal)
+			}
+		} else if aa.AnnotationProperty.AbbreviatedIRI == "rdfs:comment" {
 			if _, ok := preparedOntology.Resources[aa.IRI]; ok {
 				c := preparedOntology.Resources[aa.IRI].Comment
 				c = append(c, aa.Literal)
@@ -126,10 +125,12 @@ func prepareOntology(o owl.Ontology) ontology.OntologyPrepared {
 					comment = strings.Join(val.Comment[:], "\n\t ")
 				}
 
+				// Get DataProperty name
+
 				preparedOntology.Resources[sc.Class[0].IRI].Relationship = append(preparedOntology.Resources[sc.Class[0].IRI].Relationship, &ontology.Relationship{
 					IRI:     v.DataProperty.IRI,
 					Typ:     util.GetProtoType(v.Datatype.AbbreviatedIRI),
-					Value:   util.GetDataPropertyIRIName(v.DataProperty),
+					Value:   util.GetDataPropertyIRIName(v.DataProperty, preparedOntology),
 					Comment: comment,
 				})
 
@@ -157,7 +158,7 @@ func prepareOntology(o owl.Ontology) ontology.OntologyPrepared {
 				preparedOntology.Resources[sc.Class[0].IRI].Relationship = append(preparedOntology.Resources[sc.Class[0].IRI].Relationship, &ontology.Relationship{
 					IRI:     identifier,
 					Typ:     util.GetProtoType(v.Literal),
-					Value:   util.GetDataPropertyIRIName(v.DataProperty),
+					Value:   util.GetDataPropertyIRIName(v.DataProperty, preparedOntology),
 					Comment: comment,
 				})
 
@@ -194,6 +195,9 @@ message ResourceID {
 
 	// Create proto messages with comments
 	for _, v := range preparedOntology.Resources {
+		if v.Iri == "http://graph.clouditor.io/classes/ApplicationLog" {
+			fmt.Println("Stop here")
+		}
 		// is the counter for the message field numbers
 		i := 0
 

--- a/cmd/owl2protobuf/owl2protobuf.go
+++ b/cmd/owl2protobuf/owl2protobuf.go
@@ -227,7 +227,9 @@ message ResourceID {
 			if o.Name != "" && o.ObjectProperty != "" {
 				i += 1
 				value, typ := util.GetObjectDetail(o.ObjectProperty, rootResourceName, preparedOntology.Resources[o.Class], preparedOntology)
-				output += fmt.Sprintf("\n\t%s%s %s  = %d;", value, typ, util.ToSnakeCase(o.Name), i)
+				if value != "" && typ != "" {
+					output += fmt.Sprintf("\n\t%s%s %s  = %d;", value, typ, util.ToSnakeCase(o.Name), i)
+				}
 			}
 		}
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -84,7 +84,7 @@ func GetProtoType(s string) string {
 	case "xsd:java.util.ArrayList<Short>":
 		return "repeated uint32"
 	case "xsd:java.util.Map<String, String>": // TODO(oxisto): Do we want to use here maps, as in the CPG?
-		return "repeated string"
+		return "map<string, string>"
 	default:
 		return s
 	}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -67,9 +67,9 @@ func GetProtoType(s string) string {
 		return "bool"
 	case "xsd:String", "xsd:string", "xsd:de.fraunhofer.aisec.cpg.graph.Node", "xsd:de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression", "xsd:de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression", "xsd:de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration":
 		return "string"
-	case "xsd:java.util.ArrayList<String>", "java.util.List<de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration>", "java.util.List<de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression>":
+	case "xsd:java.util.ArrayList<String>", "java.util.List<de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration>", "java.util.List<de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression>", "xsd:java.util.List<de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression>", "xsd:java.util.List<de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration>":
 		return "repeated string"
-	case "xsd:integer":
+	case "xsd:integer", "xsd:int":
 		return "int32"
 	case "xsd:Short":
 		return "uint32"
@@ -79,7 +79,7 @@ func GetProtoType(s string) string {
 		return "int64"
 	case "xsd:java.time.ZonedDateTime":
 		return "google.protobuf.Timestamp"
-	case "xsd:java.util.ArrayList<Short>": // TODO(oxisto): Do we want to use here maps, as in the CPG?
+	case "xsd:java.util.ArrayList<Short>":
 		return "repeated uint32"
 	case "xsd:java.util.Map<String, String>": // TODO(oxisto): Do we want to use here maps, as in the CPG?
 		return "repeated string"

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -100,11 +100,20 @@ func GetNameFromIri(s string) string {
 }
 
 // GetDataPropertyIRIName return the existing IRI (IRI vs. abbreviatedIRI) from the Data Property
-func GetDataPropertyIRIName(prop owl.DataProperty) string {
+func GetDataPropertyIRIName(prop owl.DataProperty, preparedOntology ontology.OntologyPrepared) string {
+	// It is possible, that the IRI/abbreviatedIRI name is not correct, therefore we have to get the correct name from the preparedOntology. Otherwise, we get the name directly from the IRI/abbreviatedIRI
 	if prop.AbbreviatedIRI != "" {
-		return GetDataPropertyAbbreviatedIriName(prop.AbbreviatedIRI)
+		if val, ok := preparedOntology.AnnotationAssertion[prop.AbbreviatedIRI]; ok {
+			return val.Name
+		} else {
+			return GetDataPropertyAbbreviatedIriName(prop.AbbreviatedIRI)
+		}
 	} else if prop.IRI != "" {
-		return GetNameFromIri(prop.IRI)
+		if val, ok := preparedOntology.Resources[prop.IRI]; ok {
+			return val.Name
+		} else {
+			return GetNameFromIri(prop.IRI)
+		}
 	}
 
 	return ""

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -26,8 +26,10 @@ func GetObjectDetail(s, rootResourceName string, resource *ontology.Resource, pr
 		value = Repeated
 	case "prop:offersInterface":
 		value = ""
-	case "prop:proxyTarget", "prop:parent":
+	case "prop:proxyTarget":
 		return "string", ""
+	case "prop:parent":
+		return "", ""
 	default:
 		return s, ""
 	}

--- a/ontology/prepared.go
+++ b/ontology/prepared.go
@@ -5,7 +5,7 @@ import "github.com/oxisto/owl2protobuf/owl"
 type OntologyPrepared struct {
 	Resources           map[string]*Resource
 	SubClasses          map[string]owl.SubClassOf
-	AnnotationAssertion map[string]owl.AnnotationAssertion
+	AnnotationAssertion map[string]*AnnotationAssertion
 }
 
 type Resource struct {
@@ -19,12 +19,21 @@ type Resource struct {
 }
 
 type Relationship struct {
-	Typ   string
-	Value string
+	IRI     string
+	Typ     string
+	Value   string
+	Comment string
 }
 
 type ObjectRelationship struct {
 	ObjectProperty string
 	Class          string // IRI
 	Name           string // Name of Class IRI
+	Comment        string // Comment of the property
+}
+
+type AnnotationAssertion struct {
+	IRI     string
+	Name    string
+	Comment []string
 }

--- a/owl/owl_xml.go
+++ b/owl/owl_xml.go
@@ -17,6 +17,7 @@ type Declaration struct {
 type AnnotationAssertion struct {
 	AnnotationProperty AnnotationProperty `xml:"AnnotationProperty"`
 	IRI                string             `xml:"IRI"`
+	AbbreviatedIRI     string             `xml:"attr"`
 	Literal            string             `xml:"Literal"`
 }
 
@@ -51,6 +52,7 @@ type SubClassOf struct {
 	ObjectSomeValuesFrom []ObjectSomeValuesFrom `xml:"ObjectSomeValuesFrom"`
 	DataSomeValuesFrom   []DataSomeValuesFrom   `xml:"DataSomeValuesFrom"`
 	ObjectHasValue       []ObjectHasValue       `xml:"ObjectHasValue"`
+	DataHasValue         []DataHasValue         `xml:"DataHasValue"`
 }
 
 type ObjectSomeValuesFrom struct {
@@ -61,6 +63,11 @@ type ObjectSomeValuesFrom struct {
 type DataSomeValuesFrom struct {
 	DataProperty DataProperty `xml:"DataProperty"`
 	Datatype     Datatype     `xml:"Datatype"`
+}
+
+type DataHasValue struct {
+	DataProperty DataProperty `xml:"DataProperty"`
+	Literal      string       `xml:"Literal"`
 }
 
 type Datatype struct {

--- a/proto.go
+++ b/proto.go
@@ -1,3 +1,0 @@
-package owl2protobuf
-
-//go:generate buf generate

--- a/proto.go
+++ b/proto.go
@@ -1,4 +1,3 @@
 package owl2protobuf
 
 //go:generate buf generate
-//go:generate buf generate --template buf.openapi.gen.yaml --path api/ -o openapi/


### PR DESCRIPTION
Updats and additions for comments from Clouditor branch (https://github.com/clouditor/clouditor/pull/1305):
- Add DataHasValue
- Update proto types
- Ignore object and data properties with "prop:parent" 
- Use label names instead of IRIs
- Start message comment with "X is an entity in our Cloud ontology"
- Add proto type map  for "xsd:java.util.Map<String, String>"