### PR TITLE
Add all properties of a path to child node

### DIFF
--- a/cmd/owl2proto/owl2proto.go
+++ b/cmd/owl2proto/owl2proto.go
@@ -265,33 +265,33 @@ enum ResourceType {
 	for _, rmk := range resourceMapKeys {
 		class := preparedOntology.Resources[rmk]
 
-		if len(class.SubResources) == 0 {
-			// is the counter for the message field numbers
-			i := 1
+		//if len(class.SubResources) == 0 {
+		// is the counter for the message field numbers
+		i := 1
 
-			// is the counter for the oneof fields
-			j := 100
+		// is the counter for the oneof fields
+		j := 100
 
-			// Add message comment
-			output += fmt.Sprintf("\n// %s is an entity class in our ontology.", class.Name)
+		// Add message comment
+		output += fmt.Sprintf("\n// %s is an entity class in our ontology.", class.Name)
 
-			// Add comment
-			for _, w := range class.Comment {
-				output += "\n// " + w
-			}
-
-			// Start message
-			output += fmt.Sprintf("\nmessage %s {", class.Name)
-
-			// Add data properties, e.g., "bool enabled", "int64 interval", "int64 retention_period"
-			output, i = addDataProperties(output, rmk, i, preparedOntology)
-
-			// Add object properties, e.g., "string compute_id", "ApplicationLogging application_logging", "TransportEncryption transport_encrypton"
-			output, _, _ = addObjectProperties(output, rmk, i, j, preparedOntology)
-
-			// Close message
-			output += "\n}\n"
+		// Add comment
+		for _, w := range class.Comment {
+			output += "\n// " + w
 		}
+
+		// Start message
+		output += fmt.Sprintf("\nmessage %s {", class.Name)
+
+		// Add data properties, e.g., "bool enabled", "int64 interval", "int64 retention_period"
+		output, i = addDataProperties(output, rmk, i, preparedOntology)
+
+		// Add object properties, e.g., "string compute_id", "ApplicationLogging application_logging", "TransportEncryption transport_encrypton"
+		output, _, _ = addObjectProperties(output, rmk, i, j, preparedOntology)
+
+		// Close message
+		output += "\n}\n"
+		//}
 	}
 
 	return output

--- a/cmd/owl2proto/owl2proto.go
+++ b/cmd/owl2proto/owl2proto.go
@@ -15,12 +15,6 @@ import (
 	"github.com/lmittmann/tint"
 )
 
-// TODOs
-// - get label instead of iri for the name fields
-// - add data/object property comments
-// - add ObjectHasValue
-// - add cli
-
 var (
 	owlFile          string
 	headerFile       string

--- a/cmd/owl2proto/owl2proto.go
+++ b/cmd/owl2proto/owl2proto.go
@@ -283,32 +283,11 @@ enum ResourceType {
 			// Start message
 			output += fmt.Sprintf("\nmessage %s {", class.Name)
 
-			// We only add properties for "leaf" nodes
-			// if len(class.SubResources) == 0 {
 			// Add data properties, e.g., "bool enabled", "int64 interval", "int64 retention_period"
 			output, i = addDataProperties(output, rmk, i, preparedOntology)
 
 			// Add object properties, e.g., "string compute_id", "ApplicationLogging application_logging", "TransportEncryption transport_encrypton"
 			output, _, _ = addObjectProperties(output, rmk, i, j, preparedOntology)
-			/*} else {
-				// Otherwise, we add sub-classes
-
-				// j is the counter for the oneof field numbers
-				j := 100
-				output += "\n\toneof type {"
-				// Sort slice of sub-resources
-				sort.Slice(class.SubResources, func(i, j int) bool {
-					a := class.SubResources[i]
-					b := class.SubResources[j]
-					return a.Name < b.Name
-				})
-				for _, v2 := range class.SubResources {
-					j += 1
-					output += fmt.Sprintf("\n\t\t%s %s = %d;", v2.Name, util.ToSnakeCase(v2.Name), j)
-
-				}
-				output += "\n\t}"
-			} */
 
 			// Close message
 			output += "\n}\n"

--- a/cmd/owl2proto/owl2proto.go
+++ b/cmd/owl2proto/owl2proto.go
@@ -232,8 +232,34 @@ func createProtoFile(preparedOntology ontology.OntologyPrepared, header string) 
 	//Add header
 	output += "\n\n" + header
 
+	// Add EnumValueOptions
+	output += `
+extend google.protobuf.EnumValueOptions {
+	optional string resource_type_name = 123456789;
+}`
+
 	// Sort preparedOntology.Resources map keys
 	resourceMapKeys := util.SortMapKeys(preparedOntology.Resources)
+
+	// Add ResourceType enum
+	output += `
+enum ResourceType {
+	RESOURCE_TYPE_UNSPECIFIED = 0;`
+
+	// Add all resource type entries
+	// i is the counter for the enum field numbers
+	i := 1
+	for _, rmk := range resourceMapKeys {
+		i += 1
+		resourceTypeList := getResourceTypeList(preparedOntology.Resources[rmk], &preparedOntology)
+
+		// For examle, ABAC has the resource types "ABAC,Authorization,SecurityFeature" and is presented as RESOURCE_ABAC_AUTHORIZATION_SECURITYFEATURE.
+		// TODO(all): Or do we want instead RESOURCE_ABAC_AUTHORIZATION_SECURITY_FEATURE?
+		output += fmt.Sprintf("\n\tRESOURCE_TYPE_%s = %d [(resource_type_name) = \"%s\"];", strings.ToUpper(strings.Join(resourceTypeList, "_")), i, strings.Join(resourceTypeList, ","))
+	}
+
+	// Close ResourceType enum
+	output += "}\n"
 
 	// Create proto messages with comments
 	for _, rmk := range resourceMapKeys {
@@ -413,6 +439,20 @@ func writeProtofileToStorage(outputFile, s string) error {
 	}
 
 	return nil
+}
+
+// getResourceTypeList returns a list of all derived resources
+func getResourceTypeList(resource *ontology.Resource, preparedOntology *ontology.OntologyPrepared) []string {
+	var resource_types []string
+
+	if resource.Parent == "" {
+		return []string{resource.Name}
+	} else {
+		resource_types = append(resource_types, resource.Name)
+		resource_types = append(resource_types, getResourceTypeList(preparedOntology.Resources[resource.Parent], preparedOntology)...)
+	}
+
+	return resource_types
 }
 
 func main() {

--- a/cmd/owl2proto/owl2proto.go
+++ b/cmd/owl2proto/owl2proto.go
@@ -265,49 +265,51 @@ enum ResourceType {
 	for _, rmk := range resourceMapKeys {
 		class := preparedOntology.Resources[rmk]
 
-		// is the counter for the message field numbers
-		i := 1
-
-		// Add message comment
-		output += fmt.Sprintf("\n// %s is an entity class in our ontology.", class.Name)
-
-		// Add comment
-		for _, w := range class.Comment {
-			output += "\n// " + w
-		}
-
-		// Start message
-		output += fmt.Sprintf("\nmessage %s {", class.Name)
-
-		// We only add properties for "leaf" nodes
 		if len(class.SubResources) == 0 {
-			// Add data properties, e.g., "bool enabled", "int64 interval", "int64 retention_period"
-			output, i = addDataProperties(output, rmk, i, preparedOntology)
+			// is the counter for the message field numbers
+			i := 1
 
-			// Add object properties, e.g., "string compute_id", "ApplicationLogging application_logging", "TransportEncryption transport_encrypton"
-			output, _ = addObjectProperties(output, rmk, i, preparedOntology)
-		} else {
-			// Otherwise, we add sub-classes
+			// Add message comment
+			output += fmt.Sprintf("\n// %s is an entity class in our ontology.", class.Name)
 
-			// j is the counter for the oneof field numbers
-			j := 100
-			output += "\n\toneof type {"
-			// Sort slice of sub-resources
-			sort.Slice(class.SubResources, func(i, j int) bool {
-				a := class.SubResources[i]
-				b := class.SubResources[j]
-				return a.Name < b.Name
-			})
-			for _, v2 := range class.SubResources {
-				j += 1
-				output += fmt.Sprintf("\n\t\t%s %s = %d;", v2.Name, util.ToSnakeCase(v2.Name), j)
-
+			// Add comment
+			for _, w := range class.Comment {
+				output += "\n// " + w
 			}
-			output += "\n\t}"
-		}
 
-		// Close message
-		output += "\n}\n"
+			// Start message
+			output += fmt.Sprintf("\nmessage %s {", class.Name)
+
+			// We only add properties for "leaf" nodes
+			if len(class.SubResources) == 0 {
+				// Add data properties, e.g., "bool enabled", "int64 interval", "int64 retention_period"
+				output, i = addDataProperties(output, rmk, i, preparedOntology)
+
+				// Add object properties, e.g., "string compute_id", "ApplicationLogging application_logging", "TransportEncryption transport_encrypton"
+				output, _ = addObjectProperties(output, rmk, i, preparedOntology)
+			} else {
+				// Otherwise, we add sub-classes
+
+				// j is the counter for the oneof field numbers
+				j := 100
+				output += "\n\toneof type {"
+				// Sort slice of sub-resources
+				sort.Slice(class.SubResources, func(i, j int) bool {
+					a := class.SubResources[i]
+					b := class.SubResources[j]
+					return a.Name < b.Name
+				})
+				for _, v2 := range class.SubResources {
+					j += 1
+					output += fmt.Sprintf("\n\t\t%s %s = %d;", v2.Name, util.ToSnakeCase(v2.Name), j)
+
+				}
+				output += "\n\t}"
+			}
+
+			// Close message
+			output += "\n}\n"
+		}
 	}
 
 	return output

--- a/cmd/owl2proto/owl2proto.go
+++ b/cmd/owl2proto/owl2proto.go
@@ -265,51 +265,30 @@ enum ResourceType {
 	for _, rmk := range resourceMapKeys {
 		class := preparedOntology.Resources[rmk]
 
-		if len(class.SubResources) == 0 {
-			// is the counter for the message field numbers
-			i := 1
+		//if len(class.SubResources) == 0 {
+		// is the counter for the message field numbers
+		i := 1
 
-			// Add message comment
-			output += fmt.Sprintf("\n// %s is an entity class in our ontology.", class.Name)
+		// Add message comment
+		output += fmt.Sprintf("\n// %s is an entity class in our ontology.", class.Name)
 
-			// Add comment
-			for _, w := range class.Comment {
-				output += "\n// " + w
-			}
-
-			// Start message
-			output += fmt.Sprintf("\nmessage %s {", class.Name)
-
-			// We only add properties for "leaf" nodes
-			if len(class.SubResources) == 0 {
-				// Add data properties, e.g., "bool enabled", "int64 interval", "int64 retention_period"
-				output, i = addDataProperties(output, rmk, i, preparedOntology)
-
-				// Add object properties, e.g., "string compute_id", "ApplicationLogging application_logging", "TransportEncryption transport_encrypton"
-				output, _ = addObjectProperties(output, rmk, i, preparedOntology)
-			} else {
-				// Otherwise, we add sub-classes
-
-				// j is the counter for the oneof field numbers
-				j := 100
-				output += "\n\toneof type {"
-				// Sort slice of sub-resources
-				sort.Slice(class.SubResources, func(i, j int) bool {
-					a := class.SubResources[i]
-					b := class.SubResources[j]
-					return a.Name < b.Name
-				})
-				for _, v2 := range class.SubResources {
-					j += 1
-					output += fmt.Sprintf("\n\t\t%s %s = %d;", v2.Name, util.ToSnakeCase(v2.Name), j)
-
-				}
-				output += "\n\t}"
-			}
-
-			// Close message
-			output += "\n}\n"
+		// Add comment
+		for _, w := range class.Comment {
+			output += "\n// " + w
 		}
+
+		// Start message
+		output += fmt.Sprintf("\nmessage %s {", class.Name)
+
+		// Add data properties, e.g., "bool enabled", "int64 interval", "int64 retention_period"
+		output, i = addDataProperties(output, rmk, i, preparedOntology)
+
+		// Add object properties, e.g., "string compute_id", "ApplicationLogging application_logging", "TransportEncryption transport_encrypton"
+		output, _ = addObjectProperties(output, rmk, i, preparedOntology)
+
+		// Close message
+		output += "\n}\n"
+		//}
 	}
 
 	return output

--- a/cmd/owl2proto/owl2proto.go
+++ b/cmd/owl2proto/owl2proto.go
@@ -326,6 +326,7 @@ func addObjectProperties(output, rmk string, i, j int, preparedOntology ontology
 				if strings.Contains(name, "_id") {
 					output += fmt.Sprintf("\n\t%s %s = %d;", typ, util.ToSnakeCase(name), i)
 				} else if len(leafs) >= 2 {
+					// TODO(all): Increment counter to next 100
 					// begin oneof X {}
 					output += fmt.Sprintf("\n\toneof %s {", o.Name)
 					for _, v := range leafs {

--- a/cmd/owl2proto/owl2proto.go
+++ b/cmd/owl2proto/owl2proto.go
@@ -313,7 +313,7 @@ func addObjectProperties(output, rmk string, i, j int, preparedOntology ontology
 
 	// Create output for the object properties
 	for _, o := range objectProperties {
-		if o.Name == "HttpEndpoint" {
+		if o.Name == "NetworkService" {
 			fmt.Println("AHA")
 		}
 		if o.Name != "" && o.ObjectProperty != "" {
@@ -323,7 +323,7 @@ func addObjectProperties(output, rmk string, i, j int, preparedOntology ontology
 			} else if typ != "" && name != "" {
 				// Get all leafs from object property and write it as 'oneOf {}'
 				leafs := findAllLeafs(o.Class, preparedOntology)
-				if name == "parent_Resource_id" {
+				if strings.Contains(name, "_id") {
 					output += fmt.Sprintf("\n\t%s %s = %d;", typ, util.ToSnakeCase(name), i)
 				} else if len(leafs) >= 2 {
 					// begin oneof X {}
@@ -333,7 +333,7 @@ func addObjectProperties(output, rmk string, i, j int, preparedOntology ontology
 						j += 1
 					}
 
-					// close onfOf{}
+					// close oneOf{}
 					output += "\n\t}"
 				} else if len(leafs) == 1 {
 					output += fmt.Sprintf("\n\t%s %s = %d;", typ, util.ToSnakeCase(name), i)

--- a/cmd/owl2proto/owl2proto.go
+++ b/cmd/owl2proto/owl2proto.go
@@ -248,7 +248,7 @@ enum ResourceType {
 
 	// Add all resource type entries
 	// i is the counter for the enum field numbers
-	i := 1
+	i := 0
 	for _, rmk := range resourceMapKeys {
 		i += 1
 		resourceTypeList := getResourceTypeList(preparedOntology.Resources[rmk], &preparedOntology)
@@ -281,7 +281,7 @@ enum ResourceType {
 
 		// We only add properties for "leaf" nodes
 		if len(class.SubResources) == 0 {
-			// // Add data properties, e.g., "bool enabled", "int64 interval", "int64 retention_period"
+			// Add data properties, e.g., "bool enabled", "int64 interval", "int64 retention_period"
 			output, i = addDataProperties(output, rmk, i, preparedOntology)
 
 			// Add object properties, e.g., "string compute_id", "ApplicationLogging application_logging", "TransportEncryption transport_encrypton"

--- a/cmd/owl2proto/owl2proto.go
+++ b/cmd/owl2proto/owl2proto.go
@@ -296,9 +296,6 @@ func addObjectProperties(output, rmk string, i, j int, preparedOntology ontology
 
 	// Create output for the object properties
 	for _, o := range objectProperties {
-		if o.Name == "NetworkService" {
-			fmt.Println("AHA")
-		}
 		if o.Name != "" && o.ObjectProperty != "" {
 			value, typ, name := util.GetObjectDetail(o.ObjectProperty, rootResourceName, preparedOntology.Resources[o.Class], preparedOntology)
 			if value != "" && typ != "" {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -29,7 +29,7 @@ func GetObjectDetail(s, rootResourceName string, resource *ontology.Resource, pr
 	case "prop:proxyTarget":
 		return "string", "", resource.Name
 	case "prop:parent":
-		return "", "string", "parent_id"
+		return "", "string", "parent_" + resource.Name + "_id"
 	default:
 		rep = ""
 	}
@@ -79,10 +79,8 @@ func GetProtoType(s string) string {
 	case "xsd:float":
 		return "float"
 	case "xsd:java.time.Duration":
-		return "int64"
-	case "xsd:dateTime":
-		return "google.protobuf.Timestamp"
-	case "xsd:java.time.ZonedDateTime":
+		return "google.protobuf.Duration"
+	case "xsd:dateTime", "xsd:java.time.ZonedDateTime":
 		return "google.protobuf.Timestamp"
 	case "xsd:java.util.ArrayList<Short>":
 		return "repeated uint32"

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -35,7 +35,7 @@ func GetObjectDetail(s, rootResourceName string, resource *ontology.Resource, pr
 	}
 
 	// If the object is a kind of the rootResourceName, the type is string and "_id" is added to the name to show that an ID is stored in the string.
-	if isResourceAboveX(resource, preparedOntology, rootResourceName) && s != "prop:to" {
+	if isResourceAboveX(resource, preparedOntology, rootResourceName) {
 		return rep, "string", resource.Name + "_id"
 	}
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -76,8 +76,10 @@ func GetProtoType(s string) string {
 		return "uint32"
 	case "xsd:float":
 		return "float"
-	case "xsd:java.time.Duration", "xsd:dateTime":
+	case "xsd:java.time.Duration":
 		return "int64"
+	case "xsd:dateTime":
+		return "google.protobuf.Timestamp"
 	case "xsd:java.time.ZonedDateTime":
 		return "google.protobuf.Timestamp"
 	case "xsd:java.util.ArrayList<Short>":

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -18,8 +18,10 @@ func GetObjectDetail(s, rootResourceName string, resource *ontology.Resource, pr
 	switch s {
 	case "prop:hasMultiple", "prop:offersMultiple":
 		rep = Repeated
-	case "prop:has", "prop:runsOn", "prop:to", "prop:offers", "prop:storage":
+	case "prop:has", "prop:runsOn", "prop:offers", "prop:storage":
 		rep = ""
+	case "prop:to":
+		rep = Repeated
 	case "prop:collectionOf":
 		rep = Repeated
 	case "prop:offersInterface":
@@ -27,13 +29,13 @@ func GetObjectDetail(s, rootResourceName string, resource *ontology.Resource, pr
 	case "prop:proxyTarget":
 		return "string", "", resource.Name
 	case "prop:parent":
-		return "", "string", "parent_" + resource.Name + "_id"
+		return "", "string", "parent_id"
 	default:
 		rep = ""
 	}
 
 	// If the object is a kind of the rootResourceName, the type is string and "_id" is added to the name to show that an ID is stored in the string.
-	if isResourceAboveX(resource, preparedOntology, rootResourceName) {
+	if isResourceAboveX(resource, preparedOntology, rootResourceName) && s != "prop:to" {
 		return rep, "string", resource.Name + "_id"
 	}
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -28,6 +28,8 @@ func GetObjectDetail(s, rootResourceName string, resource *ontology.Resource, pr
 		rep = ""
 	case "prop:proxyTarget":
 		return "string", "", resource.Name
+	case "prop:parent":
+		return "", "string", "parent_id"
 	default:
 		rep = ""
 	}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -28,8 +28,6 @@ func GetObjectDetail(s, rootResourceName string, resource *ontology.Resource, pr
 		rep = ""
 	case "prop:proxyTarget":
 		return "string", "", resource.Name
-	case "prop:parent":
-		return "", "string", "parent_" + resource.Name + "_id"
 	default:
 		rep = ""
 	}
@@ -79,7 +77,7 @@ func GetProtoType(s string) string {
 	case "xsd:float":
 		return "float"
 	case "xsd:java.time.Duration":
-		return "google.protobuf.Duration"
+		return "int64" //return "google.protobuf.Duration"
 	case "xsd:dateTime", "xsd:java.time.ZonedDateTime":
 		return "google.protobuf.Timestamp"
 	case "xsd:java.util.ArrayList<Short>":

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -77,7 +77,7 @@ func GetProtoType(s string) string {
 	case "xsd:float":
 		return "float"
 	case "xsd:java.time.Duration":
-		return "int64" //return "google.protobuf.Duration"
+		return "google.protobuf.Duration"
 	case "xsd:dateTime", "xsd:java.time.ZonedDateTime":
 		return "google.protobuf.Timestamp"
 	case "xsd:java.util.ArrayList<Short>":


### PR DESCRIPTION
This PR adds all path properties into the proto message of the child nodes. Furthermore, the following has been updated: 
- [x] Add types
- [x] Add 'offersInterface'﻿ properties as oneOf, e.g. oneOf AccessRestriction{l3Firewall, webApplicationFirewall}﻿
- [x] Use google.protobuf.Duration
- [x] There are still problems with nested security features, we need to decide how they are represented in the JSON, so Rego works
- [x] Change `parent_resource_id` to `parent_id`
