### PR TITLE
Add `Named Individuals` processing and `Annotation Assertions` normalization

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch owl2proto with exmple",
+            "name": "Launch owl2proto with example",
             "type": "go",
             "request": "launch",
             "mode": "auto",

--- a/commands/proto.go
+++ b/commands/proto.go
@@ -60,7 +60,7 @@ func (cmd *GenerateProtoCmd) createProto(header string) string {
 			output += fmt.Sprintf("\n// %s is an abstract class in our ontology, it cannot be instantiated but acts as an \"interface\".", class.Name)
 		}
 
-		// Add comment
+		// Add field comment
 		for _, w := range class.Comment {
 			output += "\n// " + w
 		}
@@ -168,7 +168,7 @@ func (cmd *GenerateProtoCmd) emitPropertyOptions(r *ontology.Relationship) strin
 	)
 	// Make name and id mandatory
 	// TODO(oxisto): somehow extract this out of the ontology file itself which fields have constraints
-	if r.Value == "name" || r.Value == "id" {
+	if r.Name == "name" || r.Name == "id" {
 		opts = append(opts, "(buf.validate.field).required = true")
 	}
 
@@ -300,12 +300,12 @@ func (cmd *GenerateProtoCmd) addDataProperties(output, rmk string) string {
 	sort.Slice(dataProperties, func(i, j int) bool {
 		a := dataProperties[i]
 		b := dataProperties[j]
-		return a.Value < b.Value
+		return a.Name < b.Name
 	})
 
 	// Create output for the data properties
 	for _, r := range dataProperties {
-		if r.Typ != "" && r.Value != "" {
+		if r.Typ != "" && r.Name != "" {
 			var (
 				optsOutput  string
 				fieldNumber = 0
@@ -315,7 +315,7 @@ func (cmd *GenerateProtoCmd) addDataProperties(output, rmk string) string {
 			resourceTypeList := cmd.getResourceTypeList(cmd.preparedOntology.Resources[rmk])
 
 			// Get field number
-			resourceTypeList = append(resourceTypeList, r.Value)
+			resourceTypeList = append(resourceTypeList, r.Name)
 			fieldNumber, cmd.i = util.GetFieldNumber(cmd.DeterministicFieldNumbers, cmd.i, resourceTypeList...)
 
 			optsOutput = cmd.emitPropertyOptions(r)
@@ -325,7 +325,7 @@ func (cmd *GenerateProtoCmd) addDataProperties(output, rmk string) string {
 				output += fmt.Sprintf("\n\t// %s", r.Comment)
 			}
 
-			output += fmt.Sprintf("\n\t%s %s = %d%s;", r.Typ, util.ToSnakeCase(r.Value), fieldNumber, optsOutput)
+			output += fmt.Sprintf("\n\t%s %s = %d%s;", r.Typ, util.ToSnakeCase(r.Name), fieldNumber, optsOutput)
 		}
 	}
 

--- a/example/example.proto
+++ b/example/example.proto
@@ -6,111 +6,124 @@ package example.v1;
 
 import "buf/validate/validate.proto";
 import "google/protobuf/descriptor.proto";
-
-option go_package = "github.com/oxisto/owl2proto/example";
-
 import "owl/owl.proto";
 
-
+option go_package = "github.com/oxisto/owl2proto/example";
 option (owl.meta) = {
-	prefixes: [{
-	prefix: "rdfs"
-	iri: "http://www.w3.org/2000/01/rdf-schema#"
-},{
-	prefix: "ex"
-	iri: "http://example.com/cloud/"
-},{
-	prefix: "owl"
-	iri: "http://www.w3.org/2002/07/owl#"
-},{
-	prefix: "rdf"
-	iri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-},{
-	prefix: "xml"
-	iri: "http://www.w3.org/XML/1998/namespace"
-},{
-	prefix: "xsd"
-	iri: "http://www.w3.org/2001/XMLSchema#"
-}]};
+  prefixes: [
+    {
+      prefix: "rdfs"
+      iri: "http://www.w3.org/2000/01/rdf-schema#"
+    },
+    {
+      prefix: "ex"
+      iri: "http://example.com/cloud/"
+    },
+    {
+      prefix: "owl"
+      iri: "http://www.w3.org/2002/07/owl#"
+    },
+    {
+      prefix: "rdf"
+      iri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    },
+    {
+      prefix: "xml"
+      iri: "http://www.w3.org/XML/1998/namespace"
+    },
+    {
+      prefix: "xsd"
+      iri: "http://www.w3.org/2001/XMLSchema#"
+    }
+  ]
+};
 
 // BlockStorage is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
 message BlockStorage {
-	option (owl.class).iri = "ex:BlockStorage";
-	option (owl.class).parent = "ex:Storage";
-	option (owl.class).parent = "ex:Resource";
-	option (owl.class).parent = "owl:Thing";
+  option (owl.class).iri = "ex:BlockStorage";
+  option (owl.class).parent = "ex:Storage";
+  option (owl.class).parent = "ex:Resource";
+  option (owl.class).parent = "owl:Thing";
 
-	string name = 8027 [ (buf.validate.field).required = true,
-	(owl.property).iri = "ex:name",
-	(owl.property).parent = "owl:topDataProperty",
-	(owl.property).class_iri = "ex:Resource" ];
+  string name = 8027 [
+    (buf.validate.field).required = true,
+    (owl.property).iri = "ex:name",
+    (owl.property).parent = "owl:topDataProperty",
+    (owl.property).class_iri = "ex:Resource"
+  ];
 }
 
 // Compute is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
 message Compute {
-
-	oneof type {
-		Container container = 15127;
-		VirtualMachine virtual_machine = 3481;
-	}
+  oneof type {
+    Container container = 15127;
+    VirtualMachine virtual_machine = 3481;
+  }
 }
 
 // Container is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
 message Container {
-	option (owl.class).iri = "ex:Container";
-	option (owl.class).parent = "ex:Compute";
-	option (owl.class).parent = "ex:Resource";
-	option (owl.class).parent = "owl:Thing";
+  option (owl.class).iri = "ex:Container";
+  option (owl.class).parent = "ex:Compute";
+  option (owl.class).parent = "ex:Resource";
+  option (owl.class).parent = "owl:Thing";
 
-	string name = 15153 [ (buf.validate.field).required = true,
-	(owl.property).iri = "ex:name",
-	(owl.property).parent = "owl:topDataProperty",
-	(owl.property).class_iri = "ex:Resource" ];
-	GeoLocation geo_location = 9969 [ (owl.property).iri = "ex:has",
-	(owl.property).parent = "owl:topObjectProperty",
-	(owl.property).class_iri = "ex:Compute" ];
+  string name = 15153 [
+    (buf.validate.field).required = true,
+    (owl.property).iri = "ex:name",
+    (owl.property).parent = "owl:topDataProperty",
+    (owl.property).class_iri = "ex:Resource"
+  ];
+  GeoLocation geo_location = 9969 [
+    (owl.property).iri = "ex:has",
+    (owl.property).parent = "owl:topObjectProperty",
+    (owl.property).class_iri = "ex:Compute"
+  ];
 }
 
 // GeoLocation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
 message GeoLocation {
-	option (owl.class).iri = "ex:GeoLocation";
-	option (owl.class).parent = "owl:Thing";
-
+  option (owl.class).iri = "ex:GeoLocation";
+  option (owl.class).parent = "owl:Thing";
 }
 
 // Resource is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
 message Resource {
-
-	oneof type {
-		Container container = 15127;
-		VirtualMachine virtual_machine = 3481;
-		BlockStorage block_storage = 14627;
-	}
+  oneof type {
+    Container container = 15127;
+    VirtualMachine virtual_machine = 3481;
+    BlockStorage block_storage = 14627;
+  }
 }
 
 // Storage is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
 message Storage {
-
-	oneof type {
-		BlockStorage block_storage = 14627;
-	}
+  oneof type {
+    BlockStorage block_storage = 14627;
+  }
 }
 
 // VirtualMachine is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
 message VirtualMachine {
-	option (owl.class).iri = "ex:VirtualMachine";
-	option (owl.class).parent = "ex:Compute";
-	option (owl.class).parent = "ex:Resource";
-	option (owl.class).parent = "owl:Thing";
+  option (owl.class).iri = "ex:VirtualMachine";
+  option (owl.class).parent = "ex:Compute";
+  option (owl.class).parent = "ex:Resource";
+  option (owl.class).parent = "owl:Thing";
 
-	string name = 5214 [ (buf.validate.field).required = true,
-	(owl.property).iri = "ex:name",
-	(owl.property).parent = "owl:topDataProperty",
-	(owl.property).class_iri = "ex:Resource" ];
-	repeated string block_storage_ids  = 6443 [ (owl.property).iri = "ex:hasMultiple",
-	(owl.property).parent = "owl:topObjectProperty",
-	(owl.property).class_iri = "ex:VirtualMachine" ];
-	GeoLocation geo_location = 12691 [ (owl.property).iri = "ex:has",
-	(owl.property).parent = "owl:topObjectProperty",
-	(owl.property).class_iri = "ex:Compute" ];
+  string name = 5214 [
+    (buf.validate.field).required = true,
+    (owl.property).iri = "ex:name",
+    (owl.property).parent = "owl:topDataProperty",
+    (owl.property).class_iri = "ex:Resource"
+  ];
+  repeated string block_storage_ids = 6443 [
+    (owl.property).iri = "ex:hasMultiple",
+    (owl.property).parent = "owl:topObjectProperty",
+    (owl.property).class_iri = "ex:VirtualMachine"
+  ];
+  GeoLocation geo_location = 12691 [
+    (owl.property).iri = "ex:has",
+    (owl.property).parent = "owl:topObjectProperty",
+    (owl.property).class_iri = "ex:Compute"
+  ];
 }

--- a/example/example.proto
+++ b/example/example.proto
@@ -6,124 +6,111 @@ package example.v1;
 
 import "buf/validate/validate.proto";
 import "google/protobuf/descriptor.proto";
-import "owl/owl.proto";
 
 option go_package = "github.com/oxisto/owl2proto/example";
+
+import "owl/owl.proto";
+
+
 option (owl.meta) = {
-  prefixes: [
-    {
-      prefix: "rdf"
-      iri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    },
-    {
-      prefix: "xml"
-      iri: "http://www.w3.org/XML/1998/namespace"
-    },
-    {
-      prefix: "xsd"
-      iri: "http://www.w3.org/2001/XMLSchema#"
-    },
-    {
-      prefix: "rdfs"
-      iri: "http://www.w3.org/2000/01/rdf-schema#"
-    },
-    {
-      prefix: "ex"
-      iri: "http://example.com/cloud/"
-    },
-    {
-      prefix: "owl"
-      iri: "http://www.w3.org/2002/07/owl#"
-    }
-  ]
-};
+	prefixes: [{
+	prefix: "rdfs"
+	iri: "http://www.w3.org/2000/01/rdf-schema#"
+},{
+	prefix: "ex"
+	iri: "http://example.com/cloud/"
+},{
+	prefix: "owl"
+	iri: "http://www.w3.org/2002/07/owl#"
+},{
+	prefix: "rdf"
+	iri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+},{
+	prefix: "xml"
+	iri: "http://www.w3.org/XML/1998/namespace"
+},{
+	prefix: "xsd"
+	iri: "http://www.w3.org/2001/XMLSchema#"
+}]};
 
 // BlockStorage is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
 message BlockStorage {
-  option (owl.class).iri = "ex:BlockStorage";
-  option (owl.class).parent = "ex:Storage";
-  option (owl.class).parent = "ex:Resource";
-  option (owl.class).parent = "owl:Thing";
+	option (owl.class).iri = "ex:BlockStorage";
+	option (owl.class).parent = "ex:Storage";
+	option (owl.class).parent = "ex:Resource";
+	option (owl.class).parent = "owl:Thing";
 
-  string name = 8027 [
-    (buf.validate.field).required = true,
-    (owl.property).iri = "ex:name",
-    (owl.property).parent = "owl:topDataProperty",
-    (owl.property).class_iri = "ex:Resource"
-  ];
+	string name = 8027 [ (buf.validate.field).required = true,
+	(owl.property).iri = "ex:name",
+	(owl.property).parent = "owl:topDataProperty",
+	(owl.property).class_iri = "ex:Resource" ];
 }
 
 // Compute is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
 message Compute {
-  oneof type {
-    Container container = 15127;
-    VirtualMachine virtual_machine = 3481;
-  }
+
+	oneof type {
+		Container container = 15127;
+		VirtualMachine virtual_machine = 3481;
+	}
 }
 
 // Container is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
 message Container {
-  option (owl.class).iri = "ex:Container";
-  option (owl.class).parent = "ex:Compute";
-  option (owl.class).parent = "ex:Resource";
-  option (owl.class).parent = "owl:Thing";
+	option (owl.class).iri = "ex:Container";
+	option (owl.class).parent = "ex:Compute";
+	option (owl.class).parent = "ex:Resource";
+	option (owl.class).parent = "owl:Thing";
 
-  string name = 15153 [
-    (buf.validate.field).required = true,
-    (owl.property).iri = "ex:name",
-    (owl.property).parent = "owl:topDataProperty",
-    (owl.property).class_iri = "ex:Resource"
-  ];
-  GeoLocation geo_location = 9969 [
-    (owl.property).iri = "ex:has",
-    (owl.property).parent = "owl:topObjectProperty",
-    (owl.property).class_iri = "ex:Compute"
-  ];
+	string name = 15153 [ (buf.validate.field).required = true,
+	(owl.property).iri = "ex:name",
+	(owl.property).parent = "owl:topDataProperty",
+	(owl.property).class_iri = "ex:Resource" ];
+	GeoLocation geo_location = 9969 [ (owl.property).iri = "ex:has",
+	(owl.property).parent = "owl:topObjectProperty",
+	(owl.property).class_iri = "ex:Compute" ];
 }
 
 // GeoLocation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
 message GeoLocation {
-  option (owl.class).iri = "ex:GeoLocation";
-  option (owl.class).parent = "owl:Thing";
+	option (owl.class).iri = "ex:GeoLocation";
+	option (owl.class).parent = "owl:Thing";
+
 }
 
 // Resource is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
 message Resource {
-  oneof type {
-    Container container = 15127;
-    VirtualMachine virtual_machine = 3481;
-    BlockStorage block_storage = 14627;
-  }
+
+	oneof type {
+		Container container = 15127;
+		VirtualMachine virtual_machine = 3481;
+		BlockStorage block_storage = 14627;
+	}
 }
 
 // Storage is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
 message Storage {
-  oneof type {
-    BlockStorage block_storage = 14627;
-  }
+
+	oneof type {
+		BlockStorage block_storage = 14627;
+	}
 }
 
 // VirtualMachine is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
 message VirtualMachine {
-  option (owl.class).iri = "ex:VirtualMachine";
-  option (owl.class).parent = "ex:Compute";
-  option (owl.class).parent = "ex:Resource";
-  option (owl.class).parent = "owl:Thing";
+	option (owl.class).iri = "ex:VirtualMachine";
+	option (owl.class).parent = "ex:Compute";
+	option (owl.class).parent = "ex:Resource";
+	option (owl.class).parent = "owl:Thing";
 
-  string name = 5214 [
-    (buf.validate.field).required = true,
-    (owl.property).iri = "ex:name",
-    (owl.property).parent = "owl:topDataProperty",
-    (owl.property).class_iri = "ex:Resource"
-  ];
-  repeated string block_storage_ids = 6443 [
-    (owl.property).iri = "ex:hasMultiple",
-    (owl.property).parent = "owl:topObjectProperty",
-    (owl.property).class_iri = "ex:VirtualMachine"
-  ];
-  GeoLocation geo_location = 12691 [
-    (owl.property).iri = "ex:has",
-    (owl.property).parent = "owl:topObjectProperty",
-    (owl.property).class_iri = "ex:Compute"
-  ];
+	string name = 5214 [ (buf.validate.field).required = true,
+	(owl.property).iri = "ex:name",
+	(owl.property).parent = "owl:topDataProperty",
+	(owl.property).class_iri = "ex:Resource" ];
+	repeated string block_storage_ids  = 6443 [ (owl.property).iri = "ex:hasMultiple",
+	(owl.property).parent = "owl:topObjectProperty",
+	(owl.property).class_iri = "ex:VirtualMachine" ];
+	GeoLocation geo_location = 12691 [ (owl.property).iri = "ex:has",
+	(owl.property).parent = "owl:topObjectProperty",
+	(owl.property).class_iri = "ex:Compute" ];
 }

--- a/example/example.proto
+++ b/example/example.proto
@@ -12,6 +12,14 @@ option go_package = "github.com/oxisto/owl2proto/example";
 option (owl.meta) = {
   prefixes: [
     {
+      prefix: "rdf"
+      iri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    },
+    {
+      prefix: "xml"
+      iri: "http://www.w3.org/XML/1998/namespace"
+    },
+    {
       prefix: "xsd"
       iri: "http://www.w3.org/2001/XMLSchema#"
     },
@@ -26,14 +34,6 @@ option (owl.meta) = {
     {
       prefix: "owl"
       iri: "http://www.w3.org/2002/07/owl#"
-    },
-    {
-      prefix: "rdf"
-      iri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    },
-    {
-      prefix: "xml"
-      iri: "http://www.w3.org/XML/1998/namespace"
     }
   ]
 };

--- a/example/example.proto
+++ b/example/example.proto
@@ -12,10 +12,6 @@ option go_package = "github.com/oxisto/owl2proto/example";
 option (owl.meta) = {
   prefixes: [
     {
-      prefix: "xml"
-      iri: "http://www.w3.org/XML/1998/namespace"
-    },
-    {
       prefix: "xsd"
       iri: "http://www.w3.org/2001/XMLSchema#"
     },
@@ -34,6 +30,10 @@ option (owl.meta) = {
     {
       prefix: "rdf"
       iri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    },
+    {
+      prefix: "xml"
+      iri: "http://www.w3.org/XML/1998/namespace"
     }
   ]
 };

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -31,7 +31,7 @@ func GetProtoType(s string) string {
 	switch s {
 	case "xsd:boolean":
 		return "bool"
-	case "xsd:String", "xsd:string", "http://graph.clouditor.io/classes/resourceId":
+	case "xsd:String", "xsd:string", "string":
 		return "string"
 	case "xsd:listString", "xsd:java.util.ArrayList<String>":
 		return "repeated string"

--- a/ontology/iri.go
+++ b/ontology/iri.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NormalizedIRI returns the normalized (abbreviated) IRI
-func NormalizedIRI[T *owl.Entity | owl.AnnotationAssertion | owl.DataProperty](ont *OntologyPrepared, c T) string {
+func NormalizedIRI[T *owl.Entity | owl.AnnotationAssertion | owl.DataProperty | owl.ObjectProperty](ont *OntologyPrepared, c T) string {
 	switch v := any(c).(type) {
 	case *owl.Entity:
 		if v.IRI != "" {
@@ -22,6 +22,12 @@ func NormalizedIRI[T *owl.Entity | owl.AnnotationAssertion | owl.DataProperty](o
 			return ont.normalizeAbbreviatedIRI(v.AbbreviatedIRI)
 		}
 	case owl.DataProperty:
+		if v.IRI != "" {
+			return v.IRI
+		} else if v.AbbreviatedIRI != "" {
+			return ont.normalizeAbbreviatedIRI(v.AbbreviatedIRI)
+		}
+	case owl.ObjectProperty:
 		if v.IRI != "" {
 			return v.IRI
 		} else if v.AbbreviatedIRI != "" {

--- a/ontology/iri.go
+++ b/ontology/iri.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NormalizedIRI returns the normalized (abbreviated) IRI
-func NormalizedIRI[T *owl.Entity | owl.AnnotationAssertion](ont *OntologyPrepared, c T) string {
+func NormalizedIRI[T *owl.Entity | owl.AnnotationAssertion | owl.DataProperty](ont *OntologyPrepared, c T) string {
 	switch v := any(c).(type) {
 	case *owl.Entity:
 		if v.IRI != "" {
@@ -16,6 +16,12 @@ func NormalizedIRI[T *owl.Entity | owl.AnnotationAssertion](ont *OntologyPrepare
 			return ont.normalizeAbbreviatedIRI(v.AbbreviatedIRI)
 		}
 	case owl.AnnotationAssertion:
+		if v.IRI != "" {
+			return v.IRI
+		} else if v.AbbreviatedIRI != "" {
+			return ont.normalizeAbbreviatedIRI(v.AbbreviatedIRI)
+		}
+	case owl.DataProperty:
 		if v.IRI != "" {
 			return v.IRI
 		} else if v.AbbreviatedIRI != "" {

--- a/ontology/prepared.go
+++ b/ontology/prepared.go
@@ -1,6 +1,7 @@
 package ontology
 
 import (
+	"fmt"
 	"log/slog"
 	"strings"
 
@@ -117,12 +118,12 @@ func Prepare(src *owl.Ontology, rootIRI string) *OntologyPrepared {
 
 		// Prepare ontology data properties
 		if c.DataProperty.IRI != "" {
-			preparedOntology.AnnotationAssertion[c.DataProperty.IRI] = &AnnotationAssertion{
+			preparedOntology.AnnotationAssertion[NormalizedIRI(preparedOntology, c.DataProperty)] = &AnnotationAssertion{
 				IRI:  c.DataProperty.IRI,
 				Name: util.CleanString(GetNameFromIri(c.DataProperty.IRI)),
 			}
 		} else if c.DataProperty.AbbreviatedIRI != "" {
-			preparedOntology.AnnotationAssertion[c.DataProperty.AbbreviatedIRI] = &AnnotationAssertion{
+			preparedOntology.AnnotationAssertion[NormalizedIRI(preparedOntology, c.DataProperty)] = &AnnotationAssertion{
 				IRI:  c.DataProperty.AbbreviatedIRI,
 				Name: util.CleanString(GetDataPropertyAbbreviatedIriName(c.DataProperty.AbbreviatedIRI)),
 			}
@@ -233,6 +234,7 @@ func Prepare(src *owl.Ontology, rootIRI string) *OntologyPrepared {
 					comment = strings.Join(val.Comment[:], "\n\t ")
 				}
 
+				fmt.Println(NormalizedIRI(preparedOntology, &v.DataProperty.Entity))
 				// Get DataProperty name
 				preparedOntology.Resources[fromIri].Relationship = append(preparedOntology.Resources[fromIri].Relationship, &Relationship{
 					IRI:     NormalizedIRI(preparedOntology, &v.DataProperty.Entity),

--- a/ontology/prepared.go
+++ b/ontology/prepared.go
@@ -155,7 +155,7 @@ func Prepare(src *owl.Ontology, rootIRI string) *OntologyPrepared {
 		}
 	}
 
-	// Prepare name and comment
+	// Prepare name, comment and types from rdfs labels
 	for _, aa := range src.AnnotationAssertion {
 		// Prepare name from "rdfs:label"
 		if aa.AnnotationProperty.AbbreviatedIRI == "rdfs:label" {
@@ -183,7 +183,7 @@ func Prepare(src *owl.Ontology, rootIRI string) *OntologyPrepared {
 			}
 		}
 
-		// Prepare type for named individuals from "rdfs:seeAlso"
+		// Prepare data type for named individuals from "rdfs:seeAlso"
 		if aa.AnnotationProperty.AbbreviatedIRI == "rdfs:seeAlso" {
 			if _, ok := preparedOntology.NamedIndividual[NormalizedIRI(preparedOntology, aa)]; ok {
 				preparedOntology.NamedIndividual[NormalizedIRI(preparedOntology, aa)].Type = aa.Literal

--- a/ontology/prepared.go
+++ b/ontology/prepared.go
@@ -32,8 +32,8 @@ type Resource struct {
 
 type Relationship struct {
 	IRI     string
-	Typ     string
-	Value   string
+	Typ     string // Data type
+	Name    string // Name of the IRI
 	Comment string
 	From    string // IRI
 }
@@ -148,8 +148,8 @@ func Prepare(src *owl.Ontology, rootIRI string) *OntologyPrepared {
 		if aa.AnnotationProperty.AbbreviatedIRI == "rdfs:label" {
 			if _, ok := preparedOntology.Resources[NormalizedIRI(preparedOntology, aa)]; ok {
 				preparedOntology.Resources[NormalizedIRI(preparedOntology, aa)].Name = util.CleanString(aa.Literal)
-			} else if _, ok := preparedOntology.AnnotationAssertion[aa.AbbreviatedIRI]; ok {
-				preparedOntology.AnnotationAssertion[aa.AbbreviatedIRI].Name = util.CleanString(aa.Literal)
+			} else if _, ok := preparedOntology.AnnotationAssertion[aa.IRI]; ok {
+				preparedOntology.AnnotationAssertion[aa.IRI].Name = util.CleanString(aa.Literal)
 			}
 		}
 
@@ -237,7 +237,7 @@ func Prepare(src *owl.Ontology, rootIRI string) *OntologyPrepared {
 				preparedOntology.Resources[fromIri].Relationship = append(preparedOntology.Resources[fromIri].Relationship, &Relationship{
 					IRI:     NormalizedIRI(preparedOntology, &v.DataProperty.Entity),
 					Typ:     util.GetProtoType(v.Datatype.AbbreviatedIRI),
-					Value:   preparedOntology.GetDataPropertyIRIName(v.DataProperty),
+					Name:    preparedOntology.AnnotationAssertion[NormalizedIRI(preparedOntology, &v.DataProperty.Entity)].Name,
 					From:    fromIri,
 					Comment: comment,
 				})
@@ -261,7 +261,7 @@ func Prepare(src *owl.Ontology, rootIRI string) *OntologyPrepared {
 				preparedOntology.Resources[fromIri].Relationship = append(preparedOntology.Resources[NormalizedIRI(preparedOntology, &sc.Class[0].Entity)].Relationship, &Relationship{
 					IRI:     relationshipIri,
 					Typ:     util.GetProtoType(v.Literal),
-					Value:   preparedOntology.GetDataPropertyIRIName(v.DataProperty),
+					Name:    preparedOntology.AnnotationAssertion[NormalizedIRI(preparedOntology, &v.DataProperty.Entity)].Name,
 					From:    fromIri,
 					Comment: comment,
 				})
@@ -301,7 +301,7 @@ func Prepare(src *owl.Ontology, rootIRI string) *OntologyPrepared {
 				preparedOntology.Resources[fromIri].Relationship = append(preparedOntology.Resources[fromIri].Relationship, &Relationship{
 					IRI:     relationshipIri,
 					Typ:     util.GetProtoType(preparedOntology.NamedIndividual[typeIri].Type),
-					Value:   preparedOntology.GetObjectPropertyIRIName(v.ObjectProperty),
+					Name:    preparedOntology.GetObjectPropertyIRIName(v.ObjectProperty),
 					From:    fromIri,
 					Comment: comment,
 				})

--- a/ontology/prepared.go
+++ b/ontology/prepared.go
@@ -1,7 +1,6 @@
 package ontology
 
 import (
-	"fmt"
 	"log/slog"
 	"strings"
 
@@ -129,6 +128,19 @@ func Prepare(src *owl.Ontology, rootIRI string) *OntologyPrepared {
 			}
 		}
 
+		// Prepare ontology object properties
+		if c.ObjectProperty.IRI != "" {
+			preparedOntology.AnnotationAssertion[NormalizedIRI(preparedOntology, c.ObjectProperty)] = &AnnotationAssertion{
+				IRI:  c.ObjectProperty.IRI,
+				Name: util.CleanString(GetNameFromIri(c.ObjectProperty.IRI)),
+			}
+		} else if c.ObjectProperty.AbbreviatedIRI != "" {
+			preparedOntology.AnnotationAssertion[NormalizedIRI(preparedOntology, c.ObjectProperty)] = &AnnotationAssertion{
+				IRI:  c.ObjectProperty.AbbreviatedIRI,
+				Name: util.CleanString(GetDataPropertyAbbreviatedIriName(c.ObjectProperty.AbbreviatedIRI)),
+			}
+		}
+
 		// Prepare ontology named individuals
 		if c.NamedIndividual.IRI != "" {
 			preparedOntology.NamedIndividual[c.NamedIndividual.IRI] = &NamedIndividual{
@@ -234,7 +246,6 @@ func Prepare(src *owl.Ontology, rootIRI string) *OntologyPrepared {
 					comment = strings.Join(val.Comment[:], "\n\t ")
 				}
 
-				fmt.Println(NormalizedIRI(preparedOntology, &v.DataProperty.Entity))
 				// Get DataProperty name
 				preparedOntology.Resources[fromIri].Relationship = append(preparedOntology.Resources[fromIri].Relationship, &Relationship{
 					IRI:     NormalizedIRI(preparedOntology, &v.DataProperty.Entity),

--- a/ontology/prepared.go
+++ b/ontology/prepared.go
@@ -124,7 +124,7 @@ func Prepare(src *owl.Ontology, rootIRI string) *OntologyPrepared {
 		} else if c.DataProperty.AbbreviatedIRI != "" {
 			preparedOntology.AnnotationAssertion[NormalizedIRI(preparedOntology, c.DataProperty)] = &AnnotationAssertion{
 				IRI:  c.DataProperty.AbbreviatedIRI,
-				Name: util.CleanString(GetDataPropertyAbbreviatedIriName(c.DataProperty.AbbreviatedIRI)),
+				Name: util.CleanString(GetDataPropertyNameWithoutPrefix(c.DataProperty.AbbreviatedIRI)),
 			}
 		}
 
@@ -137,7 +137,7 @@ func Prepare(src *owl.Ontology, rootIRI string) *OntologyPrepared {
 		} else if c.ObjectProperty.AbbreviatedIRI != "" {
 			preparedOntology.AnnotationAssertion[NormalizedIRI(preparedOntology, c.ObjectProperty)] = &AnnotationAssertion{
 				IRI:  c.ObjectProperty.AbbreviatedIRI,
-				Name: util.CleanString(GetDataPropertyAbbreviatedIriName(c.ObjectProperty.AbbreviatedIRI)),
+				Name: util.CleanString(GetDataPropertyNameWithoutPrefix(c.ObjectProperty.AbbreviatedIRI)),
 			}
 		}
 
@@ -150,7 +150,7 @@ func Prepare(src *owl.Ontology, rootIRI string) *OntologyPrepared {
 		} else if c.NamedIndividual.AbbreviatedIRI != "" {
 			preparedOntology.NamedIndividual[c.NamedIndividual.AbbreviatedIRI] = &NamedIndividual{
 				IRI:  c.NamedIndividual.AbbreviatedIRI,
-				Name: util.CleanString(GetDataPropertyAbbreviatedIriName(c.NamedIndividual.AbbreviatedIRI)),
+				Name: util.CleanString(GetDataPropertyNameWithoutPrefix(c.NamedIndividual.AbbreviatedIRI)),
 			}
 		}
 	}
@@ -332,7 +332,7 @@ func (ont *OntologyPrepared) GetDataPropertyIRIName(prop owl.DataProperty) strin
 		if val, ok := ont.AnnotationAssertion[prop.AbbreviatedIRI]; ok {
 			return val.Name
 		} else {
-			return GetDataPropertyAbbreviatedIriName(prop.AbbreviatedIRI)
+			return GetDataPropertyNameWithoutPrefix(prop.AbbreviatedIRI)
 		}
 	} else if prop.IRI != "" {
 		if val, ok := ont.Resources[prop.IRI]; ok {
@@ -353,7 +353,7 @@ func (ont *OntologyPrepared) GetObjectPropertyIRIName(prop owl.ObjectProperty) s
 		if val, ok := ont.AnnotationAssertion[prop.AbbreviatedIRI]; ok {
 			return val.Name
 		} else {
-			return GetDataPropertyAbbreviatedIriName(prop.AbbreviatedIRI)
+			return GetDataPropertyNameWithoutPrefix(prop.AbbreviatedIRI)
 		}
 	} else if prop.IRI != "" {
 		if val, ok := ont.Resources[prop.IRI]; ok {

--- a/ontology/prepared.go
+++ b/ontology/prepared.go
@@ -170,8 +170,8 @@ func Prepare(src *owl.Ontology, rootIRI string) *OntologyPrepared {
 			}
 		}
 
-		// Prepare type for named individuals from "rdf:type"
-		if aa.AnnotationProperty.AbbreviatedIRI == "rdf:type" {
+		// Prepare type for named individuals from "rdfs:seeAlso"
+		if aa.AnnotationProperty.AbbreviatedIRI == "rdfs:seeAlso" {
 			if _, ok := preparedOntology.NamedIndividual[NormalizedIRI(preparedOntology, aa)]; ok {
 				preparedOntology.NamedIndividual[NormalizedIRI(preparedOntology, aa)].Type = aa.Literal
 			}

--- a/ontology/properties.go
+++ b/ontology/properties.go
@@ -36,8 +36,8 @@ func GetNameFromIri(s string) string {
 	return split[len(split)-1]
 }
 
-// GetDataPropertyAbbreviatedIriName returns the abbreviatedIRI name, e.g. "prop:enabled" returns "enabled"
-func GetDataPropertyAbbreviatedIriName(s string) string {
+// GetDataPropertyNameWithoutPrefix returns the abbreviatedIRI name, e.g. "prop:enabled" returns "enabled"
+func GetDataPropertyNameWithoutPrefix(s string) string {
 	if s == "" {
 		return ""
 	}

--- a/ontology/properties_test.go
+++ b/ontology/properties_test.go
@@ -28,7 +28,7 @@ func TestGetDataPropertyAbbreviatedIriName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetDataPropertyAbbreviatedIriName(tt.args.s); got != tt.want {
+			if got := GetDataPropertyNameWithoutPrefix(tt.args.s); got != tt.want {
 				t.Errorf("GetDataPropertyAbbreviatedIriName() = %v, want %v", got, tt.want)
 			}
 		})

--- a/uml.go
+++ b/uml.go
@@ -54,7 +54,7 @@ func addDataProperties(output, iri string, po *ontology.OntologyPrepared) string
 	props := po.Resources[iri].Relationship
 
 	for _, prop := range props {
-		output += fmt.Sprintf("\t%s\n", prop.Value)
+		output += fmt.Sprintf("\t%s\n", prop.Name)
 	}
 
 	return output


### PR DESCRIPTION
This PR adds the following: 
- add `Named Individuals` processing. It is now possible for an Individual with the annotation property `rdfs:seeAlso` to utilize the annotation value as a data type.
- `Annotation Assertions` are now saved with the normalized IRI in the AnnotationAssertions map in preparedOntology.
- Add `Object Properties` to `Annotation Assertions`